### PR TITLE
transmitters/livolo: call wiringPiSetup before trying to change pin mode

### DIFF
--- a/transmitters/livolo/livolo.cpp
+++ b/transmitters/livolo/livolo.cpp
@@ -243,10 +243,10 @@ int main(int argc, char **argv)
   int errflg=0;
   int c, j;
   
-  Livolo liv(output_pin);
-  
   if (wiringPiSetup () == -1)
 		exit (1) ;
+
+  Livolo liv(output_pin);
 
    // Sort out the options first!
    //


### PR DESCRIPTION
Setting pin mode to output won't work before calling wiringPiSetup().

Signed-off-by: Roi Dayan roi.dayan@gmail.com
