### PR TITLE
imposible to use custom output_pin (argument -p) because livolo objec…

### DIFF
--- a/transmitters/livolo/livolo.cpp
+++ b/transmitters/livolo/livolo.cpp
@@ -243,7 +243,6 @@ int main(int argc, char **argv)
   int errflg=0;
   int c, j;
   
-  Livolo liv(output_pin);
   
   if (wiringPiSetup () == -1)
 		exit (1) ;
@@ -340,6 +339,8 @@ int main(int argc, char **argv)
 		printf("\n");
 	}
 	
+  Livolo liv(output_pin);
+
   // 
   // Main LOOP
   //


### PR DESCRIPTION
…t created before parsing arguments